### PR TITLE
[renderer] Change FPS and overlay locations, fix close button in 3D, and visual fixes

### DIFF
--- a/src/enviroment/class/Instance.lua
+++ b/src/enviroment/class/Instance.lua
@@ -828,12 +828,17 @@ function Instance:QueryDescendants(selector)
 end
 
 function Instance:SetMetadata(key, value)
-	self._meta = self._meta or {}
-	self._meta[key] = value
+	local meta = rawget(self, "_meta")
+	if not meta then
+		meta = {}
+		rawset(self, "_meta", meta)
+	end
+	meta[key] = value
 end
 
 function Instance:GetMetadata(key)
-	return self._meta and self._meta[key]
+	local meta = rawget(self, "_meta")
+	return meta and meta[key]
 end
 
 function Instance:GetAttribute(name)

--- a/src/enviroment/game/runtime/PlayerGui.lua
+++ b/src/enviroment/game/runtime/PlayerGui.lua
@@ -11,7 +11,12 @@ PlayerGui.InitRenderer = function(renderer, renderer_signal)
 	PlayerGui.ChildAdded:Connect(function(child)
 		if type(child) == "table" and child.BaseClass == "UIContainer" then
 			if child["render"] then
-				renderer.Pool.new("2d", function()
+				local renderId
+				renderId = renderer.Pool.new("2d", function()
+					if not child.render then
+						renderer.Pool.Destroy(renderId)
+						return
+					end
 					local dt = renderer.Raylib.lib.GetFrameTime()
 					child.render(renderer.Raylib.lib, child, dt, renderer.Raylib.structs, renderer)
 				end, -5)

--- a/src/enviroment/game/services/Lighting/Lighting.luau
+++ b/src/enviroment/game/services/Lighting/Lighting.luau
@@ -206,14 +206,22 @@ Lighting.InitRenderer = function(renderer, renderer_signal, datamodel)
 
 				rlib.R3D_UpdateProceduralSky(cubemapSky, skyObject)
 			end
-			local blurEffect = Lighting:FindFirstChildOfClass("BlurEffect")
-
-			if blurEffect then
-				renderer.Blur.blurRadius = blurEffect.Size
-				renderer.Blur:DrawFullBlur(const.WHITE)
-			end
 		end
 	end)
+
+	renderer.Pool.new("3d", function()
+		local highestBlur = 0
+		for i, blur in pairs(Lighting:QueryDescendants(">BlurEffect")) do
+			if blur.Enabled then
+				highestBlur = math.max(highestBlur, blur.Size)
+			end
+		end
+		
+		if highestBlur then
+			renderer.Blur.blurRadius = highestBlur
+			renderer.Blur:DrawFullBlur(const.WHITE)
+		end
+	end, -1048576)
 
 	Lighting.ChildAdded:Connect(handleLightingChild)
 end

--- a/src/modules/Aereon/component/objects/navigation.luau
+++ b/src/modules/Aereon/component/objects/navigation.luau
@@ -43,6 +43,7 @@ return function(objects, data)
 		iconSize = 24,
 		padding = 8,
 		spacing = 8,
+		scrollStep = 20,
 		dividerHeight = 1,
 		expandSpeed = 12,
 		font = data.font or raylib.lib.GetFontDefault(),
@@ -56,6 +57,7 @@ return function(objects, data)
 		hoveredIndex = -1,
 		selectedIndex = -1,
 		scrollOffset = 0,
+		scrollTarget = 0,
 		isExpanded = false,
 		textAlpha = 0,
 
@@ -201,14 +203,16 @@ return function(objects, data)
 
 		-- Handle scrolling
 		if isHovering then
-			config.scrollOffset = config.scrollOffset - scrollWheel * 20
+			config.scrollTarget = config.scrollTarget - scrollWheel * config.scrollStep
 		end
+		config.scrollOffset = config.scrollOffset + (config.scrollTarget - config.scrollOffset) * (math.min(1, dt * 10) ^ 0.5)
 
 		config.hoveredIndex = -1
 		local currentY = r.y + config.padding - config.scrollOffset
 
 		raylib.lib.BeginScissorMode(r.x, r.y, config.currentWidth, r.height)
 
+		local collapseOffset = config.isExpanded and 0 or (config.currentWidth - config.collapsedWidth) / 2
 		for i, item in ipairs(config.items) do
 			if item.type == "divider" then
 				-- Draw divider
@@ -247,10 +251,10 @@ return function(objects, data)
 				currentY = currentY + 20
 			else
 				-- Regular item
-				local itemX = config.isExpanded and r.x + config.padding
-					or r.x + (config.currentWidth - config.itemSize) / 2
-				local itemRenderWidth = config.isExpanded and (config.currentWidth - config.padding * 2)
-					or config.itemSize
+				local itemX = config.isExpanded and r.x + config.padding * 1.5
+					or r.x + (config.currentWidth - config.itemSize) / 2 - collapseOffset
+				local itemRenderWidth = config.isExpanded and (config.currentWidth - config.padding * 2.5)
+					or config.itemSize + collapseOffset
 				local itemRect = rect.new(itemX, currentY, itemRenderWidth, config.itemSize)
 
 				local isHovered = rect.MouseIsInRect(itemRect)

--- a/src/modules/Aereon/component/objects/navigation.luau
+++ b/src/modules/Aereon/component/objects/navigation.luau
@@ -253,8 +253,8 @@ return function(objects, data)
 				-- Regular item
 				local itemX = config.isExpanded and r.x + config.padding * 1.5
 					or r.x + (config.currentWidth - config.itemSize) / 2 - collapseOffset
-				local itemRenderWidth = config.isExpanded and (config.currentWidth - config.padding * 2.5)
-					or config.itemSize + collapseOffset
+				local itemRenderWidth = config.isExpanded and (config.currentWidth - config.padding * 3)
+					or config.itemSize + collapseOffset * 2
 				local itemRect = rect.new(itemX, currentY, itemRenderWidth, config.itemSize)
 
 				local isHovered = rect.MouseIsInRect(itemRect)

--- a/src/renderer/init.luau
+++ b/src/renderer/init.luau
@@ -114,6 +114,7 @@ function KiRend.new(config: KiRendConf)
 		rendereventbus_conns = 0,
 		call3d_ms = 0,
 		dispatch_ms = 0,
+		render3d_update_ms = 0,
 	}
 
 	local newBlurInstance = blur.Init(config.width, config.height)
@@ -269,20 +270,26 @@ function KiRend.new(config: KiRendConf)
 
 		Pool = {
 			new = function(type: "2d" | "3d" | "gizmo", renderFn: () -> (), priority: number?)
-				local id = math.random(1, 99999)
+				local pool
+				if type == "2d" then
+					pool = renderer_pool.gui
+				elseif type == "3d" then
+					pool = renderer_pool.object
+				elseif type == "gizmo" then
+					pool = renderer_pool.gizmos
+				end
+
+				local id
+				repeat
+					id = math.random(1, 99999)
+				until pool[id] == nil
 				local poolEntry = {
 					render = renderFn,
 					object = nil,
 					priority = priority or 0,
 				}
 
-				if type == "2d" then
-					renderer_pool.gui[id] = poolEntry
-				elseif type == "3d" then
-					renderer_pool.object[id] = poolEntry
-				elseif type == "gizmo" then
-					renderer_pool.gizmos[id] = poolEntry
-				end
+				pool[id] = poolEntry
 
 				return id
 			end,
@@ -501,12 +508,15 @@ function KiRend.new(config: KiRendConf)
 			v(rendererObject.RuntimeLibrary)
 		end
 
+		local render3DUpdateStart = os.clock()
 		for _, item in ipairs(sorted3DPool) do
 			local entry = item.entry
 			if entry.render then
 				entry.render(rendererObject.RuntimeLibrary)
 			end
 		end
+		perf_stats.render3d_update_ms = (os.clock() - render3DUpdateStart) * 1000
+
 		meshCalls = #renderer_draw_calls
 		instancedBatches = #renderer_instanced_draw_calls
 
@@ -589,41 +599,30 @@ function KiRend.new(config: KiRendConf)
 		end
 
 		if rendererObject.DrawFps then
-			lib.DrawFPS(10, 10)
+			local fpsText = string.format("%2i FPS", lib.GetFPS())
+			local width, height = lib.GetRenderWidth(), lib.GetRenderHeight()
+
+			local size = 10
+			local textLength = lib.MeasureText(fpsText, size)
+
+			local color = structs.Color:new({r = 255, g = 255, b = 255, a = 127})
+			lib.DrawText(fpsText, width - textLength - 10, height - 10 - size, size, color)
 		end
 
 		if rendererObject.ShowPerfOverlay then
-			local color = const.WHITE
-			local y = 30
-			lib.DrawText(
+			local color = structs.Color:new({r = 255, g = 255, b = 255, a = 63})
+			local size = 10
+
+			local text = table.concat({
+				string.format("Frame: %.3f ms | FPS: %d | Dispatch: %.3f ms", perf_stats.frame_ms, perf_stats.fps, perf_stats.dispatch_ms),
 				string.format(
-					"Frame: %.2f ms | FPS: %d | Dispatch: %.2f ms",
-					perf_stats.frame_ms,
-					perf_stats.fps,
-					perf_stats.dispatch_ms
-				),
-				10,
-				y,
-				18,
-				color
-			)
-			y += 18
-			lib.DrawText(
-				string.format(
-					"Update: %.2f ms | UI: %.2f ms | UI Roots: %d",
+					"Update: %.3f ms | UI: %.3f ms | UI Roots: %d",
 					perf_stats.update_ms,
 					perf_stats.ui_ms,
 					perf_stats.gui_roots
 				),
-				10,
-				y,
-				18,
-				color
-			)
-			y += 18
-			lib.DrawText(
 				string.format(
-					"3D: %.2f ms | Batches: %d (%d mesh + %d inst) | Instances: %d | 3D Roots: %d",
+					"3D: %.3f ms | Batches: %d (%d mesh + %d inst) | Instances: %d | 3D Roots: %d",
 					perf_stats.render3d_ms,
 					perf_stats.batches_3d,
 					perf_stats.mesh_calls,
@@ -631,23 +630,23 @@ function KiRend.new(config: KiRendConf)
 					perf_stats.instanced_instances,
 					perf_stats.scene_roots_3d
 				),
-				10,
-				y,
-				18,
-				color
-			)
-			y += 18
-			lib.DrawText(string.format("3D Drawcalls: %.2f ms", perf_stats.call3d_ms), 10, y, 18, color)
-			y += 18
-			lib.DrawText(
-				string.format("Input: %.2f ms | Key Process: %.2f ms", perf_stats.input_ms, perf_stats.input_key_ms),
-				10,
-				y,
-				18,
-				color
-			)
-			y += 18
-			lib.DrawText(string.format("RenderBus Connections: %d", perf_stats.rendereventbus_conns), 10, y, 18, color)
+				string.format(
+					"3D Drawcalls: %.3f ms | 3D Pool Update: %.3f ms",
+					perf_stats.call3d_ms,
+					perf_stats.render3d_update_ms
+				),
+				string.format(
+					"Input: %.3f ms | Key Process: %.3f ms",
+					perf_stats.input_ms,
+					perf_stats.input_key_ms
+				),
+				string.format(
+					"RenderBus Connections: %d",
+					perf_stats.rendereventbus_conns
+				),
+			}, "\n")
+
+			lib.DrawText(text, 10, lib.GetRenderHeight() - 10 - (#string.split(text, "\n") + 1) * size, size, color)
 		end
 
 		perf_stats.ui_ms = (os.clock() - uiStart) * 1000
@@ -754,6 +753,10 @@ function KiRend.new(config: KiRendConf)
 			rendererObject:step(time)
 		end
 
+		rendererObject:Shutdown()
+	end
+
+	function rendererObject:Shutdown()
 		for _, callback in pairs(renderer_hooks.Shutdown) do
 			local success, result = pcall(function()
 				callback()
@@ -762,6 +765,8 @@ function KiRend.new(config: KiRendConf)
 				warn(result)
 			end
 		end
+
+		zune.process.exit(0)
 	end
 
 	function rendererObject:GetStats()
@@ -801,6 +806,7 @@ function KiRend.new(config: KiRendConf)
 				rendereventbus_conns = perf_stats.rendereventbus_conns,
 				call3d_ms = perf_stats.call3d_ms,
 				dispatch_ms = perf_stats.dispatch_ms,
+				render3d_update_ms = perf_stats.render3d_update_ms,
 			},
 			windowSize = {
 				width = lib.GetRenderWidth(),

--- a/src/sandboxed/internals/Core/aboutmenu.luau
+++ b/src/sandboxed/internals/Core/aboutmenu.luau
@@ -59,7 +59,7 @@ game.EngineSignal:Connect(function(route)
 	end
 end)
 
-renderer.Pool.new("2d", function(data)
+renderer.Hook.new("After2D", function(data)
 	if game.Context ~= Enum.GameContext.Editor then
 		return
 	end

--- a/src/sandboxed/internals/Core/toolbar.luau
+++ b/src/sandboxed/internals/Core/toolbar.luau
@@ -342,7 +342,7 @@ local fileMenu = gui.menu({
 			label = "Exit",
 			shortcut = "Alt+F4",
 			onClick = function()
-				zune.process.exit(0)
+				KinemiumRaylib.lib.CloseWindow()
 			end,
 		},
 	},


### PR DESCRIPTION
Series of commits (all with unique changes) that I forgot to separate into different PRs. Oops.

* `b665ff`
  * Clicking the Close button while a project is open will now properly close on Windows (untested on other platforms)
  * Moved FPS to bottom-right corner, perf overlay to bottom-left corner
  * Fixed PlayerGui erroring when destroying objects
  * Navigation bar now has smooth scrolling and fixed jittering geometry when expanding/collapsing
  * `renderer.Pool.new` will now attempt to avoid ID conflict
  * Overhauled internal display of overlay items
  * About window now displays in front of the work area
* `bf8a95`: Minor visual fixes in the navigation bar
* `72b68c`
  * Fixed a C stack overflow on `Instance:SetMetadata()` and `Instance:GetMetadata()`
  * BlurEffect with the largest size is used, parity with Roblox