### PR TITLE
Daylight cycle and batched material fix, black background on start

### DIFF
--- a/src/enviroment/game/services/Lighting/Lighting.luau
+++ b/src/enviroment/game/services/Lighting/Lighting.luau
@@ -31,9 +31,8 @@ local function getDayAlpha(clockTime)
 	return (clockTime % 24) / 24
 end
 
-function Lighting:GetSunDirection()
-	local time = self.ClockTime
-	local latitude = math.rad(self.GeographicLatitude)
+local function calculateSunDirection(time, latitude)
+	latitude = math.rad(latitude)
 	local declination = math.rad(23.45 * math.sin(math.rad(360 * (284 + time * 15) / 365)))
 	local hourAngle = math.rad(15 * (time - 12))
 
@@ -50,6 +49,10 @@ function Lighting:GetSunDirection()
 		math.sin(elevation),
 		math.sin(azimuth) * math.cos(elevation)
 	)
+end
+
+function Lighting:GetSunDirection()
+	return calculateSunDirection(self.ClockTime, self.GeographicLatitude)
 end
 
 local function setSkyObject(r3d_sky)
@@ -176,7 +179,7 @@ Lighting.InitRenderer = function(renderer, renderer_signal, datamodel)
 	renderer_signal:Connect(function(route, dt)
 		if route == "RenderStepped" then
 			if Lighting.EnableDayCycle == true then
-				Lighting.ClockTime += 0.005
+				Lighting.ClockTime += dt * 1.5
 
 				local sunY = -Lighting:GetSunDirection().Y
 				local daylight = math.clamp((sunY + 0.1) / 0.6, 0, 1)
@@ -204,7 +207,7 @@ Lighting.InitRenderer = function(renderer, renderer_signal, datamodel)
 					Lighting:GetSunDirection():ToBuffer()
 				)
 
-				rlib.R3D_UpdateProceduralSky(cubemapSky, skyObject)
+				rlib.R3D_UpdateProceduralSky(skyObject, skyObject)
 			end
 		end
 	end)
@@ -221,6 +224,12 @@ Lighting.InitRenderer = function(renderer, renderer_signal, datamodel)
 			renderer.Blur.blurRadius = highestBlur
 			renderer.Blur:DrawFullBlur(const.WHITE)
 		end
+
+		local colorShift_Top = Lighting.ColorShift_Top:ToRaylib()
+		rlib.R3D_SetLightDirection(light, -calculateSunDirection((Lighting.ClockTime % 12) + 6, Lighting.GeographicLatitude):ToZuneVector())
+		rlib.R3D_SetLightColor(light, colorShift_Top)
+		rlib.R3D_SetLightEnergy(light, Lighting.Brightness)
+		rlib.R3D_SetLightActive(light, Lighting.GlobalShadows)
 	end, -1048576) -- why is this number so big???
 
 	Lighting.ChildAdded:Connect(handleLightingChild)

--- a/src/enviroment/game/services/Workspace/Workspace.luau
+++ b/src/enviroment/game/services/Workspace/Workspace.luau
@@ -300,6 +300,9 @@ Workspace.InitRenderer = function(renderer, signal, game)
 	end
 
 	local function loadMaterial(materialName, sync)
+		if loadedMaterials[materialName] then
+			return loadedMaterials[materialName]
+		end
 		if not availableMaterials[materialName] or availableMaterials[materialName].loading then
 			return nil
 		end
@@ -324,7 +327,7 @@ Workspace.InitRenderer = function(renderer, signal, game)
 			end
 
 			buffer.copy(albedo, r3d.structs.R3D_AlbedoMap:offset("color"), raylib.const.WHITE)
-			buffer.copy(default, r3d.structs.R3D_Material:offset("normal"), normal, 0, r3d.structs.R3D_NormalMap:size())
+			-- buffer.copy(default, r3d.structs.R3D_Material:offset("normal"), normal, 0, r3d.structs.R3D_NormalMap:size())
 			buffer.copy(default, r3d.structs.R3D_Material:offset("albedo"), albedo, 0, r3d.structs.R3D_AlbedoMap:size())
 			availableMaterials[materialName].loading = false
 
@@ -332,28 +335,28 @@ Workspace.InitRenderer = function(renderer, signal, game)
 
 			iodebug(string.format("Processed custom material %s in %.3fms", materialName, (os.clock() - materialProcessStart) * 1000))
 		end)
-
-		return loadedMaterials[materialName]
+		return nil
 	end
 
 	local function getInstancedMaterial(materialName)
-		local cached = instancedMaterialCache[materialName]
-		if cached then
-			return cached
-		end
+		-- local cached = instancedMaterialCache[materialName]
+		-- if cached then
+		-- 	return cached
+		-- end
 
+		-- local matData = loadedMaterials[materialName] or loadMaterial(materialName) or fallbackMaterial
+		-- if not matData then
+		-- 	return nil
+		-- end
+
+		-- local material = buffer.create(r3d.structs.R3D_Material:size())
+		-- buffer.copy(material, 0, matData.material, 0, r3d.structs.R3D_Material:size())
+		-- buffer.writei32(material, r3d.structs.R3D_Material:offset("transparencyMode"), 1)
+		-- buffer.writei32(material, r3d.structs.R3D_Material:offset("cullMode"), 1)
+
+		-- instancedMaterialCache[materialName] = material
 		local matData = loadedMaterials[materialName] or loadMaterial(materialName) or fallbackMaterial
-		if not matData then
-			return nil
-		end
-
-		local material = buffer.create(r3d.structs.R3D_Material:size())
-		buffer.copy(material, 0, matData.material, 0, r3d.structs.R3D_Material:size())
-		buffer.writei32(material, r3d.structs.R3D_Material:offset("transparencyMode"), 1)
-		buffer.writei32(material, r3d.structs.R3D_Material:offset("cullMode"), 1)
-
-		instancedMaterialCache[materialName] = material
-		return material
+		return matData.material
 	end
 
 	local function queueSinglePartDraw(part, r3dAABB)
@@ -611,22 +614,21 @@ Workspace.InitRenderer = function(renderer, signal, game)
 			return
 		end
 
+		local forceDirty = false
 		if
 			Workspace.UseGpuInstancing ~= lastUseGpuInstancing
 			or Workspace.MinInstancesPerBatch ~= lastMinInstancesPerBatch
 		then
 			lastUseGpuInstancing = Workspace.UseGpuInstancing
 			lastMinInstancesPerBatch = Workspace.MinInstancesPerBatch
-			for _, chunk in pairs(chunks) do
-				chunk.dirty = true
-			end
+			forceDirty = true
 		end
 
 		local camPos = Kinemium_camera.CFrame.Position
 
 		for _, chunk in pairs(chunks) do
 			if chunkVisible(chunk, camPos, Workspace.MAX_VIEW_DISTANCE) then
-				if chunk.dirty then
+				if forceDirty or chunk.dirty then
 					rebuildChunkBatches(chunk)
 				end
 

--- a/src/renderer/init.luau
+++ b/src/renderer/init.luau
@@ -46,6 +46,13 @@ function KiRend.new(config: KiRendConf)
 	lib.SetConfigFlags(windowFlags)
 
 	lib.InitWindow(config.width, config.height, config.title)
+	
+	if lib.WindowShouldClose() == 0 then
+		lib.BeginDrawing()
+		lib.ClearBackground(const.BLACK)
+		lib.EndDrawing()
+	end
+
 	if config.maxFps and config.maxFps > 0 then
 		lib.SetTargetFPS(config.maxFps)
 	elseif not useVsync then


### PR DESCRIPTION
This PR fixes batched materials and the daylight cycle being dependent on frame rate.
In addition, a black background is rendered as the window is created for a smoother transition to the home screen. The way it is currently implemented may cause a short flicker.