### PR TITLE
Build system overhaul

### DIFF
--- a/build.luau
+++ b/build.luau
@@ -46,7 +46,7 @@ end
 
 local b_windows = flagExists("windows")
 local b_macos = flagExists("macos")
-local b_linux = flagExists("linux")
+local b_debian = flagExists("debian")
 local b_freebsd = flagExists("freebsd")
 
 local b_args = {
@@ -115,8 +115,9 @@ if b_macos or zune.platform.os == "macos" then
 	buildExecutable("macos_x86-64", ".app", "dll")
 end
 
-if b_linux or zune.platform.os == "linux" then
-	buildExecutable("linux_x86-64", "", "so")
+-- Zune's Linux release is compiled for Debian.
+if b_debian or zune.platform.os == "linux" then
+	buildExecutable("debian_x86-64", "", "so")
 end
 
 -- There is no progress on proper FreeBSD support despite

--- a/build.luau
+++ b/build.luau
@@ -1,61 +1,128 @@
---!strict
-local fs = zune.fs
-local process = zune.process
+local zpath = zune.fs.path
+local zjoin = zpath.join
 
-local function build()
-	local sArgs = {
-		"-s",
-		"src/main.lua",
-		"src/enviroment/*",
-		"src/enviroment/class/**",
-		"src/enviroment/classlibs/**",
-		"src/enviroment/datatypes/**",
-		"src/enviroment/libraries/**",
+local EXECUTABLE_NAME = "KinemiumRuntime"
+local COMPRESSION = "zstd"
 
-		"src/enviroment/game/services/Workspace/**",
-		"src/enviroment/game/services/*/*",
-		"src/enviroment/game/*",
-		"src/enviroment/game/runtime/*",
+local root = zjoin("src")
+local entry = zjoin(root, "main.luau")
 
-		"src/modules/**/*.lua*",
-		"src/renderer/**/*.lua*",
-		"src/sandboxed/**",
-		"src/runtime/**/*.lua*",
-		"src/external/**/*.lua*",
-		"src/objects/**",
-		"src/libs/**",
-		"src/**",
-		"src/external/signal.lua",
-	}
+local bin = zjoin("build")
 
-	local args = {
-		"bundle",
-		"--compression=zstd",
-		"-f",
-		"./**/.luaurc",
-		"src/assets/**",
-		"src/assets/images/**",
-		"src/assets/icon/**",
-		"src/assets/materials/**",
-		"src/assets/meshes/**",
-		"src/assets/fonts/**",
-		"src/assets/sky/**",
-		"src/projects.toml",
-		"src/assets/sounds/**",
-		"src/assets/videos/**",
-	}
+local include = {
+	zjoin(root, "**", "*.lua*")
+}
 
-	for _, line in pairs(sArgs) do
-		table.insert(args, line)
+local assets = {
+	zjoin("**", ".luaurc"),
+	zjoin(root, "assets", "**"),
+	zjoin(root, "projects.toml"),
+	zjoin(root, "sandboxed", "**")
+}
+
+local function flagExists(flag: string)
+	local args = zune.process.args
+	for _, v in pairs(args) do
+		if v == "--" .. flag then
+			return true
+		end
 	end
-	table.insert(args, "--out=./build/KinemiumRuntime.exe")
+	return false
+end
 
-	local res = process.run(fs.getExePath(), args)
-	print("Successfully built")
+local ext = ""
 
-	if not res.ok then
-		error(`\n- {res.stderr}`)
+local function copyLibraries(ext, bin, path)
+	for _, f in pairs(zune.fs.entries(path)) do
+		if f.kind == "directory" then
+			copyLibraries(ext, bin, zjoin(path, f.name))
+		elseif f.kind == "file" and zpath.globMatch(f.name, "*." .. ext) then
+			local lib = zpath.join(path, f.name)
+			print("Copying " .. f.name)
+			zune.fs.copy(lib, zjoin(bin, f.name), true)
+		end
 	end
 end
 
-build()
+local b_windows = flagExists("windows")
+local b_macos = flagExists("macos")
+local b_linux = flagExists("linux")
+local b_freebsd = flagExists("freebsd")
+
+local b_args = {
+	"bundle",
+	entry,
+	"--compression=" .. COMPRESSION,
+	"--scripts"
+}
+
+table.move(include, 1, #include, #b_args + 1, b_args)
+table.insert(b_args, "--files")
+table.move(assets, 1, #assets, #b_args + 1, b_args)
+
+if flagExists("releasefast") then
+	print("JIT is enabled; pre-compiled bytecode; O2; g0")
+	table.insert(b_args, "--release")
+	table.insert(b_args, "-O2")
+	table.insert(b_args, "-g0")
+	table.insert(b_args, "--native")
+elseif flagExists("release") then
+	print("JIT is enabled; pre-compiled bytecode enabled")
+	table.insert(b_args, "--release")
+elseif flagExists("debugvm") then
+	print("JIT is disabled; O0; g2")
+	table.insert(b_args, "-g2")
+	table.insert(b_args, "-O0")
+	table.insert(b_args, "--no-jit")
+	table.insert(b_args, "--debug")
+else
+	print("JIT is enabled; O1; g1")
+end
+
+local function buildExecutable(name, exec_ext, lib_ext)
+	print(`Creating executable:\n\tPlatform: {name}\n\tExecutable file extension: {exec_ext}\n\tLibrary file extension: {lib_ext}`)
+
+	local dir = zjoin(bin, name)
+	if zune.fs.stat(dir).kind ~= "directory" then
+		zune.fs.makeDir(dir, true)
+	end
+
+	local l_args = table.clone(b_args)
+	local l_exec = zpath.join(dir, EXECUTABLE_NAME .. exec_ext)
+
+	print("Copying libraries")
+	copyLibraries(lib_ext, dir, zpath.join(root, "external"))
+
+	print("Copying assets")
+	zune.fs.copy(zjoin(root, "assets"), zjoin(dir, "assets"), true)
+	
+	table.insert(l_args, "--out=" .. l_exec)
+
+	print("Bundling: zune " .. table.concat(l_args, " "))
+
+	local exec: ProcessRunResult = zune.process.run(zune.fs.getExePath(), l_args)
+	if not exec.ok then
+		error("could not bundle executable: " .. tostring(exec.stderr))
+	end
+	print("successfully bundled at " .. l_exec)
+end
+
+if b_windows or zune.platform.os == "windows" then
+	buildExecutable("windows_x86-64", ".exe", "dll")
+end
+
+if b_macos or zune.platform.os == "macos" then
+	buildExecutable("macos_x86-64", ".app", "dll")
+end
+
+if b_linux or zune.platform.os == "linux" then
+	buildExecutable("linux_x86-64", "", "so")
+end
+
+-- There is no progress on proper FreeBSD support despite
+-- an available native Zune executable.
+-- Linux compatibility may need to be enabled by the user,
+-- since the .so libraries are re-used from Linux.
+if b_freebsd or zune.platform.os == "freebsd" then
+	buildExecutable("freebsd_x86-64", "", "so")
+end


### PR DESCRIPTION
This is an overhaul of the current `build.luau` file at the repository root.

## Output
To support multi-bundling, binaries are placed in a folder within `./build`:
- Windows: `windows_x86-64`
- macOS: `macos_x86-64`
- Debian: `debian_x86-64`
- macOS: `freebsd_x86-64`

## Targets
The script can now build automatically within the native operating system. For example, running the build script within Debian will automatically build a Debian executable and the same is true for macOS.

All of the available targets are listed here:
- Windows x64
- macOS x64
- Debian x64
- FreeBSD x64
  - No dependencies of the engine are natively compiled for FreeBSD. Linux compatibility must be enabled by the user.

## Flags
I also took the time to add extra flags to customize the build process.

Compile flags
- `--debugvm`: opt level 0, debug level 2, source code, JIT disabled
- `--release`: default opt-debug levels, bytecode, JIT enabled
- `--releasefast`: opt level 2, debug level 0, bytecode, JIT enabled

OS flags (unstable)
- `--windows`: Force bundling for Windows
- `--macos`: Force bundling for macOS
- `--debian`: Force bundling for Debian
- `--freebsd`: Force bundling for FreeBSD

## Potential Problems
Currently, all library binaries are contained in the repository itself and there is no distinction on what architecture it supports. This may cause issues when porting the engine to ARM or RISC-V. A re-evaluation of how external libraries are used may be required to sort out this issue.

Additionally, Zune's bundling system can only create executables of itself. This means that the final binaries are suited for the operating system and architecture this was bundled on.

## Future-proofing
The new build system opens up the possibility for bundling the executable for other operating systems and architectures (TempleOS maybe?).

I have already added an option for bundling within FreeBSD, but it is a very early work and functionality is not guaranteed. At the time of writing, it uses Linux libraries to bundle and therefore may require Linux compatibility to be enabled manually.